### PR TITLE
Removed default parameters from implementation file

### DIFF
--- a/src/ezLED.cpp
+++ b/src/ezLED.cpp
@@ -31,7 +31,7 @@
 
 #include <ezLED.h>
 
-ezLED::ezLED(int pin, int mode = CTRL_ANODE) {
+ezLED::ezLED(int pin, int mode) {
 	_ledPin      = pin;
 	_ctrlMode    = mode; // CTRL_ANODE, CTRL_CATHODE
 	_ledMode     = LED_MODE_OFF;
@@ -78,7 +78,7 @@ void ezLED::updateDigital() {
 	digitalWrite(_ledPin, state);
 }
 
-void ezLED::turnON(unsigned long delayTime = 0) {
+void ezLED::turnON(unsigned long delayTime) {
 	_delayTime = delayTime;
 	_ledMode   = LED_MODE_ON;
 
@@ -92,7 +92,7 @@ void ezLED::turnON(unsigned long delayTime = 0) {
 	loop();
 }
 
-void ezLED::turnOFF(unsigned long delayTime = 0) {
+void ezLED::turnOFF(unsigned long delayTime) {
 	_delayTime = delayTime;
 	_ledMode   = LED_MODE_OFF;
 
@@ -106,7 +106,7 @@ void ezLED::turnOFF(unsigned long delayTime = 0) {
 	loop();
 }
 
-void ezLED::toggle(unsigned long delayTime = 0) {
+void ezLED::toggle(unsigned long delayTime) {
 	_delayTime = delayTime;
 	_ledMode   = LED_MODE_TOGGLE;
 
@@ -122,7 +122,7 @@ void ezLED::toggle(unsigned long delayTime = 0) {
 }
 
 
-void ezLED::fade(int fadeFrom, int fadeTo, unsigned long fadeTime, unsigned long delayTime = 0) {
+void ezLED::fade(int fadeFrom, int fadeTo, unsigned long fadeTime, unsigned long delayTime) {
 	_fadeFrom  = fadeFrom;
 	_fadeTo    = fadeTo;
 	_fadeTime  = fadeTime;
@@ -138,7 +138,7 @@ void ezLED::fade(int fadeFrom, int fadeTo, unsigned long fadeTime, unsigned long
 	loop();
 }
 
-void ezLED::blink(unsigned long onTime, unsigned long offTime, unsigned long delayTime = 0) {
+void ezLED::blink(unsigned long onTime, unsigned long offTime, unsigned long delayTime) {
 	setBlink(onTime, offTime, delayTime);
 	_ledMode      = LED_MODE_BLINK_FOREVER;
 
@@ -156,7 +156,7 @@ void ezLED::blink(unsigned long onTime, unsigned long offTime, unsigned long del
 	loop();
 }
 
-void ezLED::blinkInPeriod(unsigned long onTime, unsigned long offTime, unsigned long blinkTime, unsigned long delayTime = 0) {
+void ezLED::blinkInPeriod(unsigned long onTime, unsigned long offTime, unsigned long blinkTime, unsigned long delayTime) {
 	setBlink(onTime, offTime, delayTime);
 	_blinkTimePeriod = blinkTime;
 	_ledMode   = LED_MODE_BLINK_PERIOD;
@@ -176,7 +176,7 @@ void ezLED::blinkInPeriod(unsigned long onTime, unsigned long offTime, unsigned 
 	loop();
 }
 
-void ezLED::blinkNumberOfTimes(unsigned long onTime, unsigned long offTime, unsigned int numberOfTimes, unsigned long delayTime = 0) {
+void ezLED::blinkNumberOfTimes(unsigned long onTime, unsigned long offTime, unsigned int numberOfTimes, unsigned long delayTime) {
 	setBlink(onTime, offTime, delayTime);
 	_blinkNumberOfTimes = numberOfTimes;
 	_ledMode   = LED_MODE_BLINK_NUM_TIME;


### PR DESCRIPTION
Default parameters should only be defined in the function declaration.

Without that platformio refuses to build with -Werror:

```bash
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:34:44: error: default argument given for parameter 2 of 'ezLED::ezLED(int, int)' [-fpermissive]
 ezLED::ezLED(int pin, int mode = CTRL_ANODE) {
                                            ^
In file included from .pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:32:
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.h:89:3: note: previous specification in 'ezLED::ezLED(int, int)' here
   ezLED(int pin, int mode = CTRL_ANODE);
   ^~~~~
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:81:47: error: default argument given for parameter 1 of 'void ezLED::turnON(long unsigned int)' [-fpermissive]
 void ezLED::turnON(unsigned long delayTime = 0) {
                                               ^
In file included from .pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:32:
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.h:90:8: note: previous specification in 'void ezLED::turnON(long unsigned int)' here
   void turnON(unsigned long delayTime = 0);
        ^~~~~~
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:95:48: error: default argument given for parameter 1 of 'void ezLED::turnOFF(long unsigned int)' [-fpermissive]
 void ezLED::turnOFF(unsigned long delayTime = 0) {
                                                ^
In file included from .pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:32:
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.h:91:8: note: previous specification in 'void ezLED::turnOFF(long unsigned int)' here
   void turnOFF(unsigned long delayTime = 0);
        ^~~~~~~
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:109:47: error: default argument given for parameter 1 of 'void ezLED::toggle(long unsigned int)' [-fpermissive]
 void ezLED::toggle(unsigned long delayTime = 0) {
                                               ^
In file included from .pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:32:
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.h:92:8: note: previous specification in 'void ezLED::toggle(long unsigned int)' here
   void toggle(unsigned long delayTime = 0);
        ^~~~~~
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:125:95: error: default argument given for parameter 4 of 'void ezLED::fade(int, int, long unsigned int, long unsigned int)' [-fpermissive]
 void ezLED::fade(int fadeFrom, int fadeTo, unsigned long fadeTime, unsigned long delayTime = 0) {
                                                                                               ^
In file included from .pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:32:
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.h:94:8: note: previous specification in 'void ezLED::fade(int, int, long unsigned int, long unsigned int)' here
   void fade(int fadeFrom, int fadeTo, unsigned long fadeTime, unsigned long delayTime = 0);
        ^~~~
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:141:91: error: default argument given for parameter 3 of 'void ezLED::blink(long unsigned int, long unsigned int, long unsigned int)' [-fpermissive]
 void ezLED::blink(unsigned long onTime, unsigned long offTime, unsigned long delayTime = 0) {
                                                                                           ^
In file included from .pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:32:
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.h:96:8: note: previous specification in 'void ezLED::blink(long unsigned int, long unsigned int, long unsigned int)' here
   void blink(unsigned long onTime, unsigned long offTime, unsigned long delayTime = 0);
        ^~~~~
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:159:124: error: default argument given for parameter 4 of 'void ezLED::blinkInPeriod(long unsigned int, long unsigned int, long unsigned int, long unsigned int)' [-fpermissive]
 void ezLED::blinkInPeriod(unsigned long onTime, unsigned long offTime, unsigned long blinkTime, unsigned long delayTime = 0) {
                                                                                                                            ^
In file included from .pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:32:
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.h:97:8: note: previous specification in 'void ezLED::blinkInPeriod(long unsigned int, long unsigned int, long unsigned int, long unsigned int)' here
   void blinkInPeriod(unsigned long onTime, unsigned long offTime, unsigned long blinkTime, unsigned long delayTime = 0);
        ^~~~~~~~~~~~~
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:179:132: error: default argument given for parameter 4 of 'void ezLED::blinkNumberOfTimes(long unsigned int, long unsigned int, unsigned int, long unsigned int)' [-fpermissive]
 void ezLED::blinkNumberOfTimes(unsigned long onTime, unsigned long offTime, unsigned int numberOfTimes, unsigned long delayTime = 0) {
                                                                                                                                    ^
In file included from .pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.cpp:32:
.pio/libdeps/kabot-esp32-s3-n16r8/ezLED/src/ezLED.h:98:8: note: previous specification in 'void ezLED::blinkNumberOfTimes(long unsigned int, long unsigned int, unsigned int, long unsigned int)' here
   void blinkNumberOfTimes(unsigned long onTime, unsigned long offTime, unsigned int numberOfTimes, unsigned long delayTime = 0);
        ^~~~~~~~~~~~~~~~~~
Compiling .pio/build/kabot-esp32-s3-n16r8/lib91b/ESP32_Servo/ESP32_Servo.cpp.o
*** [.pio/build/kabot-esp32-s3-n16r8/lib154/ezLED/ezLED.cpp.o] Error 1
```